### PR TITLE
Separate development and production using env file

### DIFF
--- a/front/.gitignore
+++ b/front/.gitignore
@@ -18,3 +18,7 @@ coverage
 
 ## webpack
 dist
+
+## env
+
+.env*

--- a/front/package.json
+++ b/front/package.json
@@ -8,12 +8,12 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "start": "webpack serve --mode development",
+    "start": "webpack serve --env NODE_ENV=development --mode development",
     "test:unit": "jest",
     "coverage": "npm run test:unit -- --coverage",
     "lint": "eslint --ext js,jsx .",
     "test-w": "jest --watchAll",
-    "build": "webpack --mode production",
+    "build": "webpack --env NODE_ENV=production --mode production",
     "deploy": "aws s3 sync ./dist s3://animalphy-gyeongwon"
   },
   "dependencies": {
@@ -39,6 +39,7 @@
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
     "css-loader": "^5.1.3",
+    "dotenv-webpack": "^7.0.2",
     "eslint": "^7.22.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-import": "^2.22.1",

--- a/front/src/data/store.js
+++ b/front/src/data/store.js
@@ -2,10 +2,9 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import post from './postReducer';
 
-const store = configureStore({
+export default configureStore({
   reducer: {
     post,
   },
+  devTools: process.env.NODE_ENV === 'development',
 });
-
-export default store;

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const baseURL = 'http://localhost:8080';
+const baseURL = process.env.BASEURL;
 
 const http = axios.create({ baseURL });
 

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -1,10 +1,12 @@
 const path = require('path');
+const Dotenv = require('dotenv-webpack');
 
-module.exports = {
+module.exports = (env) => ({
   resolve: {
     extensions: ['.js', '.jsx'],
   },
   entry: path.resolve(__dirname, 'src/index.jsx'),
+  plugins: [new Dotenv({ path: `./.env.${env.NODE_ENV}` })],
   module: {
     rules: [
       {
@@ -28,4 +30,4 @@ module.exports = {
     hot: true,
     port: 1275,
   },
-};
+});

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2947,6 +2947,25 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
+dotenv-defaults@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.1.tgz#ea6f9632b3b5cc55e48b736760def5561f1cb7c0"
+  integrity sha512-ugFCyBF7ILuwpmznduHPQZBMucHHJ8T4OBManTEVjemxCm2+nqifSuW2lD2SNKdiKSH1E324kZSdJ8M04b4I/A==
+  dependencies:
+    dotenv "^8.2.0"
+
+dotenv-webpack@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-7.0.2.tgz#1bf2e407e92c10fbb08d815b12c991028f10f81c"
+  integrity sha512-RY+/5uM/XY4bGtih9f9ic8hlrUDxVcZZBPWlnX/aHhaKxcVVX9SH/5VH7CSmvVo9GL6PKvQOA0X1bc552rnatQ==
+  dependencies:
+    dotenv-defaults "^2.0.1"
+
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"


### PR DESCRIPTION
- use the environment variable to separate development and production
- to apply env file, use dotenv-webpack
- separate development url and production url in api.js
- use NODE_ENV to hide Redux DevTools browser extension when production
- to separate development and production, update scripts
- to avoid tracking .env, update gitignore