### PR TITLE
Fix typo in test code description

### DIFF
--- a/front/src/data/__tests__/postReducer.test.js
+++ b/front/src/data/__tests__/postReducer.test.js
@@ -172,7 +172,7 @@ describe('postReducer', () => {
         images: [],
       };
 
-      context('when error not occuered', () => {
+      context('when error not occurred', () => {
         beforeEach(() => {
           jest.clearAllMocks();
 
@@ -194,7 +194,7 @@ describe('postReducer', () => {
         });
       });
 
-      context('when error occuered', () => {
+      context('when error occurred', () => {
         beforeEach(() => {
           jest.clearAllMocks();
           postImage.mockImplementationOnce(() => Promise.resolve({ url: 'image-url' }));
@@ -219,7 +219,7 @@ describe('postReducer', () => {
     });
 
     describe('loadImages', () => {
-      context('when error not occuered', () => {
+      context('when error not occurred', () => {
         beforeEach(() => {
           jest.clearAllMocks();
 
@@ -240,7 +240,7 @@ describe('postReducer', () => {
         });
       });
 
-      context('when error occuered', () => {
+      context('when error occurred', () => {
         beforeEach(() => {
           jest.clearAllMocks();
 
@@ -265,7 +265,7 @@ describe('postReducer', () => {
     });
 
     describe('loadPost', () => {
-      context('when error not occuered', () => {
+      context('when error not occurred', () => {
         beforeEach(() => {
           jest.clearAllMocks();
 
@@ -286,7 +286,7 @@ describe('postReducer', () => {
         });
       });
 
-      context('when error occuered', () => {
+      context('when error occurred', () => {
         beforeEach(() => {
           jest.clearAllMocks();
 

--- a/front/src/data/__tests__/userReducer.test.js
+++ b/front/src/data/__tests__/userReducer.test.js
@@ -48,7 +48,7 @@ describe('userReducer', () => {
       error: '',
     };
 
-    context('when error not occuered', () => {
+    context('when error not occurred', () => {
       beforeEach(() => {
         jest.clearAllMocks();
 
@@ -68,7 +68,7 @@ describe('userReducer', () => {
       });
     });
 
-    context('when error occuered', () => {
+    context('when error occurred', () => {
       beforeEach(() => {
         jest.clearAllMocks();
 


### PR DESCRIPTION
- before : occuered => after : occurred
- word typos were corrected to explain the occurrence of the error.